### PR TITLE
Documentation tweak

### DIFF
--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -720,6 +720,15 @@ Just like setup and teardown methods you can pass an optional number of tests to
   sub example : Test(startup => 1) {
       ok(1, 'a startup method with one test');
   };
+  
+If you want to run an unknown number of tests within your startup method, you need to say e.g.
+
+  sub example : Test(startup => no_plan) {
+     ok(1, q{The first of many tests that don't want to have to count});
+     ...
+  }
+
+as the : Tests attribute behaves exactly like : Test in this context.
 
 If a startup method has a failing test or throws an exception then all other tests for the current test object are ignored. 
 


### PR DESCRIPTION
It took me a while digging through the code before I realised that saying

sub startup_foo : Tests(startup) {
   ...
}

wasn't going to work - the Tests attribute only fills in no_plan if there are no arguments, and there's going to be an argument if this is a startup method.

Arguably it should Do The Right Thing, but that breaks encapsulation somewhat.
