### PR TITLE
Sort the list of test classes.

### DIFF
--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -342,7 +342,7 @@ sub _isa_class {
 
 sub _test_classes {
     my $class = shift;
-    return( @{mro::get_isarev($class)}, $class );
+    return( sort @{mro::get_isarev($class)}, $class );
 };
 
 sub runtests {


### PR DESCRIPTION
It's currently returned in essentially random order, which is less than helpful. If you have a large number of test classes, it helps for similar tests (e.g. Foo::Create, Foo::Delete, Foo::Modify, Foo::Update) to be run at similar times, so you can spot that all your test failures are to do with Foo::*, and cancel a test run once you spot a pattern, rather than those class being interspersed higgledy-piggledy with other tests involving Bar, Baz,Bletch and so on.

I suspect that mro::get_isarev is internally grovelling through a Perl hash, in which case the supposedly-random order will in fact be the same every time for a given version of Perl, so it's not even a useful random order.

We're currently applying the equivalent of this patch at $WORK, via monkey-patching Test::Class because you can't actually override methods via inheritance. It would be nice for this to make the core module.
