### PR TITLE
Summarise all the classes, and methods, that failed in verbose mode.

### DIFF
--- a/t/test_verbose_failures.t
+++ b/t/test_verbose_failures.t
@@ -1,0 +1,44 @@
+#! /usr/bin/perl -T
+
+use strict;
+use warnings;
+
+package Local::Test;
+use base qw(Test::Class);
+use Test::More;
+
+sub test1 : Test { pass() };
+sub test2 : Test { fail() };
+sub test3 : Test { pass() };
+sub test4 : Test { fail() };
+
+package main;
+use Test::Builder::Tester tests => 1;
+
+my $filename = sub { return (caller)[1] }->();
+
+$ENV{TEST_VERBOSE} = 1;
+test_diag("");
+test_diag("Local::Test->test1");
+test_out("ok 1 - test1");
+test_diag("");
+test_diag("Local::Test->test2");
+test_out("not ok 2 - test2");
+test_diag("  Failed test 'test2'");
+test_diag("  at $filename line 11.");
+test_diag("  (in Local::Test->test2)");
+test_diag("");
+test_diag("Local::Test->test3");
+test_out("ok 3 - test3");
+test_diag("");
+test_diag("Local::Test->test4");
+test_out("not ok 4 - test4");
+test_diag("  Failed test 'test4'");
+test_diag("  at $filename line 13.");
+test_diag("  (in Local::Test->test4)");
+test_diag("Test failures were as follows:");
+test_diag("  Local::Test:");
+test_diag("    ->test2");
+test_diag("    ->test4");
+Local::Test->runtests;
+test_test("TEST_VERBOSE outputs method diagnostic and summary of failures");


### PR DESCRIPTION
Another thing that we've monkey-patched at $WORK: if you have a very large test class hierarchy, the standard "You had test failures at test 42, 365, 370..395, 1025, 1213, 1215" message is effectively useless. What we really want to know is, in this huge list of classes, which of them failed.

Hence this patch, to remember where any failures happened, and summarise them at the end.
