### PR TITLE
fix bad handling of exceptions that are false after being chomped, or st...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Changes for Perl extension Test-Class
 
+    -   properly handle thrown exceptions that stringify to the empty string
+        before or after chomping (Karen Etheridge, PR#11)
+
 0.41   or the "0.99 was a bad year" release [2013-11-30]
     -   require a newer Test::Builder if 0.99 is installed RT#90699
 

--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -252,6 +252,7 @@ sub _exception_failure {
     $message .= " (for test method '$Current_method')"
             if defined $Current_method && $method ne $Current_method;
     _show_header($self, @$tests);
+    chomp $exception;
     $Builder->ok(0, "$message died ($exception)");
     _threw_exception( $self, $method => 1 );
 };
@@ -289,19 +290,18 @@ sub _run_method {
     $skip_reason = eval {$self->$method};
     $skip_reason = $method unless $skip_reason;
     my $exception = $@;
-    chomp($exception) if $exception;
     my $num_done = $Builder->current_test - $num_start;
     my $num_expected = _total_num_tests($self, $method);
     $num_expected = $num_done if $num_expected eq NO_PLAN;
     if ($num_done == $num_expected) {
         _exception_failure($self, $method, $exception, $tests) 
-                unless $exception eq '';
+                if $exception;
     } elsif ($num_done > $num_expected) {
         my $class = ref $self;
         $Builder->diag("expected $num_expected test(s) in $class\::$method, $num_done completed\n");
     } else {
         until (($Builder->current_test - $num_start) >= $num_expected) {
-            if ($exception ne '') {
+            if ($exception) {
                 _exception_failure($self, $method, $exception, $tests);
                 $skip_reason = "$method died";
                 $exception = '';

--- a/t/runtests_die_empty.t
+++ b/t/runtests_die_empty.t
@@ -1,0 +1,41 @@
+#! /usr/bin/perl -T
+
+use strict;
+use warnings;
+
+package Object;
+use overload
+    bool => sub { 1 },  # there is an exception here even if it stringifies as empty!
+    '""' => 'as_string',
+    fallback => 1;
+sub new {
+    my ($class, %args) = @_;
+    bless { %args }, $class;
+}
+sub as_string {
+    return defined $_[0]->{message}
+        ? $_[0]->{message}
+        : '';
+}
+
+package Foo;
+use Test::More;
+use base qw(Test::Class);
+
+sub die_empty : Test(1) {
+        die Object->new();
+        fail 'we should never get here';
+}
+
+package main;
+use Test::Builder::Tester tests => 1;
+$ENV{TEST_VERBOSE}=0;
+
+my $filename = sub { return (caller)[1] }->();
+
+test_out( "not ok 1 - die_empty died ()");
+test_err( "#   Failed test 'die_empty died ()'" );
+test_err( "#   at $filename line 40.");
+test_err( "#   (in Foo->die_empty)" );
+Foo->runtests;
+test_test("we can handle an exception that stringifies to the empty string");

--- a/t/runtests_die_nearlyempty.t
+++ b/t/runtests_die_nearlyempty.t
@@ -1,0 +1,37 @@
+#! /usr/bin/perl -T
+
+use strict;
+use warnings;
+
+package Foo;
+use Test::More;
+use base qw(Test::Class);
+
+sub die_one_cr : Test(1) {
+        die "\n";
+        fail 'we should never get here';
+}
+
+sub die_two_cr : Test(1) {
+        die "\n\n";
+        fail 'we should never get here';
+}
+
+package main;
+use Test::Builder::Tester tests => 1;
+$ENV{TEST_VERBOSE}=0;
+
+my $filename = sub { return (caller)[1] }->();
+
+test_out( "not ok 1 - die_one_cr died ()");
+test_err( "#   Failed test 'die_one_cr died ()'" );
+test_err( "#   at $filename line 36.");
+test_err( "#   (in Foo->die_one_cr)" );
+test_out( "not ok 2 - die_two_cr died (");
+test_out( "# )");
+test_err( "#   Failed test 'die_two_cr died (" );
+test_err( "# )'");
+test_err( "#   at $filename line 36.");
+test_err( "#   (in Foo->die_two_cr)" );
+Foo->runtests;
+test_test("early die with nearly-empty messages handled");


### PR DESCRIPTION
...ringify to false

Since we were stringifying and chomping $@ before checking its original value,
exceptions consisting of "\n" or "" (or have a string overload that results in
one of these values), were giving the appearance of the test merely exiting
early, which is treated as "tests pass, but the remainder were skipped" rather
than properly being treated as a failure.
