### PR TITLE
Run teardown even if test method dies

### DIFF
--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -391,6 +391,7 @@ sub runtests {
                         _show_header($t, @tests) unless _has_no_tests($t, $method);
                         $all_passed = 0 unless _run_method($t, $method, \@tests);
                         if ( _threw_exception( $t, $method ) ) {
+			    next if ($method eq $test);
                             my $num_to_skip = _total_num_tests($t, @methods_to_run);
                             $Builder->skip( "$method died" ) for ( 1 .. $num_to_skip );
                             last;

--- a/t/teardown-when-test-dies.t
+++ b/t/teardown-when-test-dies.t
@@ -1,0 +1,28 @@
+#! /usr/bin/perl 
+
+use strict;
+use warnings;
+
+{
+    package TeardownWhenTestDies;
+    use base qw(Test::Class);
+    use Test::More;
+
+    sub setup_that_runs : Test( setup => 1 ) { ok(1, "setup works"); }
+
+    sub my_test_method : Tests {
+        die "oops!";
+    }
+
+    sub teardown_that_runs : Test( teardown => 1 ) {
+        ok(1, 'teardown is run');
+    }
+}
+
+use Test::Builder::Tester tests => 1;
+
+test_out("ok 1 - setup works\nnot ok 2 - my_test_method died (oops! at t/teardown-when-test-dies.t line 14.)\nok 3 - teardown is run");
+test_fail( +2 );
+test_err( "#   (in TeardownWhenTestDies->my_test_method)" );
+Test::Class->runtests;
+test_test("exception in method, but teardown is still run");


### PR DESCRIPTION
From 0.38 and onwards, when a test method dies, the teardown were no longer
executed. If the setup methods relies on a "clean" environment this means that
any further tests will fail (because setup fails), and will make it harder to
pinpoint the initial reason for the test failure.

A test of this functionality is included in this patch.

This fixes github issue #7
