### PR TITLE
use test_requires instead of build_requires for test deps

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,4 +1,4 @@
-use Module::Build;
+use Module::Build 0.4004;    # test_requires
 
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ my $build = Module::Build->new(
         'strict'                => '0',
         'warnings'              => '0',
     },
-    build_requires => {
+    test_requires => {
         'Test::Exception'       => '0.25',
         'IO::File'              => '1.09',
         'Test::More'            => '0.78',


### PR DESCRIPTION
This will reduce the installation requirements for people who happen to be installing this with `--notest` 
