### PR TITLE
List additional modules that use Test::Class in their test-suite

### DIFF
--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -1817,7 +1817,7 @@ The following modules use Test::Class as part of their test suite. You might wan
 
 =over 4
 
-L<Aspect>, Bricolage (L<http://www.bricolage.cc/>), L<Class::StorageFactory>, L<CGI::Application::Search>, L<DBIx::Romani>, L<Xmldoom>, L<Object::Relational>, L<File::Random>, L<Geography::JapanesePrefectures>, L<Google::Adwords>, L<Merge::HashRef>, L<PerlBuildSystem>, L<Pixie>, L<Yahoo::Marketing>, and L<XUL-Node>
+L<App-GitGot>, L<Aspect>, Bricolage (L<http://www.bricolage.cc/>), L<CHI>, L<Cinnamon>, L<Class::StorageFactory>, L<CGI::Application::Search>, L<DBIx::Romani>, L<Xmldoom>, L<Object::Relational>, L<File::Random>, L<Geography::JapanesePrefectures>, L<Google::Adwords>, L<Merge::HashRef>, L<PerlBuildSystem>, L<Ubic>, L<Pixie>, L<Yahoo::Marketing>, and L<XUL-Node>
 
 =back
 


### PR DESCRIPTION
Add 4 modules that use Test::Class in their test suite to listing.  Selected modules based on recency of last release and number of +'s on MetaCPAN