### PR TITLE
Create fail_if_returned_late, behavior is similar to fail_if_returned_early

### DIFF
--- a/lib/Test/Class.pm
+++ b/lib/Test/Class.pm
@@ -298,7 +298,11 @@ sub _run_method {
                 if $exception;
     } elsif ($num_done > $num_expected) {
         my $class = ref $self;
-        $Builder->diag("expected $num_expected test(s) in $class\::$method, $num_done completed\n");
+        if ($self->fail_if_returned_late) {
+            $Builder->ok(0, "($class\::$method returned before plan complete)");
+        } else {
+            $Builder->diag("expected $num_expected test(s) in $class\::$method, $num_done completed\n");
+        }
     } else {
         until (($Builder->current_test - $num_start) >= $num_expected) {
             if ($exception) {
@@ -319,6 +323,7 @@ sub _run_method {
 }
 
 sub fail_if_returned_early { 0 }
+sub fail_if_returned_late { 0 }
 
 sub _show_header {
     my ($self, @tests) = @_;
@@ -936,6 +941,22 @@ However, if the class's C<fail_if_returned_early> method returns true, then the 
     for (my $n=1; $n*$n<50; ++$n) {
       ok 1, "$n squared is less than fifty";
     }
+  }
+
+
+=head1 RETURNING LATE
+
+If a test method runs too many tests, by default the test plan succeeds.
+
+However, if the class's C<fail_if_returned_late> method returns true, then the extra tests will trigger a failure.  For example,
+
+  package MyClass;
+  use base 'Test::Class';
+  sub fail_if_returned_late { 1 }
+
+  sub oops : Tests(1) {
+    ok 1, "just a simple test";
+    ok 1, "just a simple test"; #oops I copied and pasted too many tests
   }
 
 
@@ -1566,6 +1587,10 @@ See the section on the L</"GENERAL FILTERING OF TESTS"> for more information.
 =item B<fail_if_returned_early>
 
 Controls what happens if a method returns before it has run all of its tests.  It is called with no arguments in boolean context; if it returns true, then the missing tests fail, otherwise, they skip.  See L<"Returning Early"> and L<"Skipped Tests">.
+
+=item B<fail_if_returned_late>
+
+Controls what happens if a method returns after running too many tests.  It is called with no arguments in boolean context; if it returns true, then the extra tests trigger a failure test.  See L<"Returning Late"> and L<"Skipped Tests">.
 
 
 =back


### PR DESCRIPTION
Please allow for stricter checking of test plans.  An option already exists for early returns.  However running too many can be just as bad.

This pull request gives Test::Class the same control over too many tests that it already had for too few.
