### PR TITLE
Revert "Fix things to work with Test::Stream"

### DIFF
--- a/t/fail2.t
+++ b/t/fail2.t
@@ -28,10 +28,9 @@ my $identifier = ($Test::More::VERSION < 0.88) ? 'object' : 'thing';
 test_out(qr/not ok 1 - (?:The $identifier|undef) isa '?Object'?\n/);
 test_out("not ok 2 - cannot create Objects");
 test_fail(-12);
-test_err( $_ ) for $INC{'Test/Stream.pm'}
-    ? (qr/#\s+(?:The $identifier|undef) isn't defined\n/, "#   (in Object::Test->_test_new)")
-    : ("#   (in Object::Test->_test_new)", qr/#\s+(?:The $identifier|undef) isn't defined\n/);
-test_fail(-16);
+test_err( "#   (in Object::Test->_test_new)" );
+test_err(qr/#\s+(?:The $identifier|undef) isn't defined\n/);
+test_fail(-15);
 test_err( "#   (in Object::Test->_test_new)" );
 
 Object::Test->runtests;

--- a/t/runtests_die.t
+++ b/t/runtests_die.t
@@ -25,11 +25,10 @@ my $identifier = ($Test::More::VERSION < 0.88) ? 'object' : 'thing';
 
 test_out( qr/not ok 1 - (?:The $identifier|undef) isa '?Object'?\n/);
 test_err( "#     Failed test ($filename at line 15)");
-test_err( $_ ) for $INC{'Test/Stream.pm'}
-    ? (qr/#     (?:The $identifier|undef) isn't defined\n/, "#   (in Foo->test_object)")
-    : ("#   (in Foo->test_object)", qr/#     (?:The $identifier|undef) isn't defined\n/);
+test_err( "#   (in Foo->test_object)" );
+test_err( qr/#     (?:The $identifier|undef) isn't defined\n/);
 test_out( "not ok 2 - test_object died (could not create object)");
-test_err("#     Failed test ($filename at line 34)");
-test_err("#   (in Foo->test_object)");
+test_err( "#     Failed test ($filename at line 33)");
+test_err( "#   (in Foo->test_object)" );
 Foo->runtests;
 test_test("early die handled");


### PR DESCRIPTION
This reverts commit 35496e7d2e04a4096291483f9fa08cf5e1f30146.

The latest Test::Stream stuff makes this previous patch unnecessary (in fact Test::Class will not pass with the new Test::Stream because of it)